### PR TITLE
Feat/style accordion

### DIFF
--- a/src/components/AccordionCard/AccordionCard.css
+++ b/src/components/AccordionCard/AccordionCard.css
@@ -5,33 +5,27 @@
   justify-content: space-between;
   padding: 0.5em 1em;
   width: 30em;
-  height: 2em;
   margin-bottom: 1em;
-  overflow: hidden; /* Hide overflowing content */
-  transition: height 0.3s ease; /*Add transition for smooth height change */
+  overflow: hidden;
+  border-bottom: solid rgb(220, 220, 220) 1px;
 }
 
-.accordion-title {
+.accordion-title-wrapper {
   display: flex;
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
-  padding: 0.5em 1em;
-  border-radius: 5px;
   background-color: #f9f9f9;
 }
 
-.accordion-title:hover {
-  background-color: #eaeaea;
+.title {
+  margin: 0;
 }
 
 .accordion-content {
-  padding: 0.5em 1em;
-  /* border: 1px solid #ccc; */
-  border-radius: 5px;
   background-color: #f9f9f9;
+  overflow: hidden;
+  transition: max-height 0.4s ease; /* Add transition property */
+  max-height: 0; /* Initially collapsed */
 }
 
-.accordion-item.open {
-  height: auto;
-}

--- a/src/components/AccordionCard/AccordionCard.css
+++ b/src/components/AccordionCard/AccordionCard.css
@@ -6,7 +6,6 @@
   padding: 0.5em 1em;
   width: 30em;
   height: 2em;
-  border: solid 1px red;
   margin-bottom: 1em;
   overflow: hidden; /* Hide overflowing content */
   transition: height 0.3s ease; /*Add transition for smooth height change */
@@ -26,18 +25,13 @@
   background-color: #eaeaea;
 }
 
-.accordion-title,
-.accordion-content {
-  padding: 1rem;
-}
-
 .accordion-content {
   padding: 0.5em 1em;
-  border: 1px solid #ccc;
+  /* border: 1px solid #ccc; */
   border-radius: 5px;
   background-color: #f9f9f9;
 }
 
 .accordion-item.open {
-  height: auto; /* Allow the container to expand to fit the content */
+  height: auto;
 }

--- a/src/components/AccordionCard/AccordionCard.jsx
+++ b/src/components/AccordionCard/AccordionCard.jsx
@@ -1,17 +1,23 @@
-import React from 'react';
-import { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import './AccordionCard.css';
 
 function AccordionCard({ title, content }) {
   const [isOpen, setIsOpen] = useState(false);
+  const contentRef = useRef(null)
+
+  useEffect(() => {
+    if(contentRef.current) {
+      contentRef.current.style.maxHeight = isOpen ? `${contentRef.current.scrollHeight}px` : '0px';
+    }
+  }, [isOpen])
 
   return (
-    <div className={`accordion-item ${isOpen ? 'open' : ''}`}>
-      <div className="accordion-title" onClick={() => setIsOpen(!isOpen)}>
-        <div>{title}</div>
+    <div className='accordion-item'>
+      <div className="accordion-title-wrapper" onClick={() => setIsOpen(!isOpen)}>
+        <h3 className='title'>{title}</h3>
         <div>{isOpen ? '-' : '+'}</div>
       </div>
-      <div className="accordion-content">
+      <div className="accordion-content" ref={contentRef}>
         <p>{content}</p>
       </div>
     </div>

--- a/src/components/AccordionCard/AccordionCard.jsx
+++ b/src/components/AccordionCard/AccordionCard.jsx
@@ -15,7 +15,12 @@ function AccordionCard({ title, content }) {
     <div className='accordion-item'>
       <div className="accordion-title-wrapper" onClick={() => setIsOpen(!isOpen)}>
         <h3 className='title'>{title}</h3>
-        <div>{isOpen ? '-' : '+'}</div>
+        <div>{isOpen ? (
+          <img src="src/assets/images/icon-minus.svg" alt="plus icon" />
+        ) : (
+          <img src='src/assets/images/icon-plus.svg' alt='minus icon'/>
+        )
+      }</div>
       </div>
       <div className="accordion-content" ref={contentRef}>
         <p>{content}</p>

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -1,8 +1,9 @@
 .app {
   background-image: url('/src/assets/images/background-pattern-desktop.svg');
-  background-size: 100% 250px;
   background-repeat: no-repeat;
-  background-position: top;
+  background-position: center top;
+  max-height: 250px;
+  background-size: cover;
 }
 
 .accordion-wrapper {
@@ -16,8 +17,7 @@
 .accordion {
   margin-top: 2em;
   padding: 1em;
-  /* border: 1px solid #ccc; */
-  border-radius: 5px;
+  border-radius: 10px;
   background-color: #f9f9f9;
 }
 

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -16,7 +16,7 @@
 .accordion {
   margin-top: 2em;
   padding: 1em;
-  border: 1px solid #ccc;
+  /* border: 1px solid #ccc; */
   border-radius: 5px;
   background-color: #f9f9f9;
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,5 +1,0 @@
-/* .header {
-  width: 100%;
-  height: 250px;
-  background-image: url('/src/assets/images/background-pattern-desktop.svg');
-} */

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,9 +1,0 @@
-import './Header.css'
-
-function Header() {
-  return (
-    <div className='header'>Header</div>
-  )
-}
-
-export default Header

--- a/src/index.css
+++ b/src/index.css
@@ -15,12 +15,8 @@ html {
   margin: 0;
 }
 
-
 body {
   margin: 0;
-  /* display: flex; */
-  /* justify-content: center; */
-  /* place-items: center; */
   min-height: 100vh;
   width: 100%;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,6 @@
   line-height: 1.5;
   font-weight: 400;
   margin: 0 auto;
-  text-align: center;
   background-color: #f9eeff;
 
   font-synthesis: none;


### PR DESCRIPTION
### Summary
- Adjusted the background image to cover the entire container and set it to a max height of 250px in App.css. 
- In AccordionCard.jsx, added the useRef hook to dynamically transition the expansion of the accordion content inside of a useEffect hook every time the isOpen state changes. 
- When isOpen is true, the maxHeight of the div contentRef is attached to is set to the scroll height of the content, otherwise, the maxHeight is 0px (when the accordion is collapsed). 
- Replaced + and - with the conditional rendering of the provided SVG icons

### Next Steps
- Add remaining SVG files
- Add fonts via @font-face
- Fix width of the bottom borders
- Adjust padding and margins
- Add breakpoints for responsive design

<img width="1320" alt="Screenshot 2024-03-23 at 12 29 24 PM" src="https://github.com/daltobello/faq-accordion/assets/130494366/6ff3c211-9136-4583-a926-465bb150109c">
<img width="1320" alt="Screenshot 2024-03-23 at 12 29 40 PM" src="https://github.com/daltobello/faq-accordion/assets/130494366/e17eab36-78aa-4a0a-b68e-7aca428510dc">
